### PR TITLE
[#31] Add support for invoking default methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+target/
+release/
+
+.idea/
+*.iml
+
+.settings/
+.classpath
+.project

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+  - oraclejdk8
   - oraclejdk7
   - openjdk7
   - openjdk6

--- a/jOOR/.gitignore
+++ b/jOOR/.gitignore
@@ -1,2 +1,0 @@
-/target
-/release

--- a/jOOR/pom.xml
+++ b/jOOR/pom.xml
@@ -40,7 +40,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.6.1</version>
                 <configuration>
                     <fork>true</fork>
                     <maxmem>512m</maxmem>
@@ -48,6 +48,8 @@
                     <encoding>UTF-8</encoding>
                     <source>1.6</source>
                     <target>1.6</target>
+                    <testSource>1.8</testSource>
+                    <testTarget>1.8</testTarget>
                     <debug>true</debug>
                     <debuglevel>lines,vars,source</debuglevel>
                 </configuration>

--- a/jOOR/src/main/java/org/joor/Reflect.java
+++ b/jOOR/src/main/java/org/joor/Reflect.java
@@ -13,6 +13,7 @@
  */
 package org.joor;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -43,6 +44,7 @@ import java.util.Map;
  *
  * @author Lukas Eder
  * @author Irek Matysiewicz
+ * @author Thomas Darimont
  */
 public class Reflect {
 
@@ -549,7 +551,7 @@ public class Reflect {
      * @return A proxy for the wrapped object
      */
     @SuppressWarnings("unchecked")
-    public <P> P as(Class<P> proxyType) {
+    public <P> P as(final Class<P> proxyType) {
         final boolean isMap = (object instanceof Map);
         final InvocationHandler handler = new InvocationHandler() {
             @SuppressWarnings("null")
@@ -578,6 +580,10 @@ public class Reflect {
                             map.put(property(name.substring(3)), args[0]);
                             return null;
                         }
+                    }
+
+                    if (JavaSupport.DefaultMethodSupport.isDefaultMethod(method)) {
+                        return JavaSupport.DefaultMethodSupport.invokeDefaultMethod(proxy, proxyType, method, args);
                     }
 
                     throw e;
@@ -806,4 +812,69 @@ public class Reflect {
     }
 
     private static class NULL {}
+
+    static class JavaSupport {
+
+        static final boolean JAVA_7_OR_HIGHER = isJava7orHigher();
+
+        static final boolean JAVA_8_OR_HIGHER = isJava8orHigher();
+
+        private static boolean isJava7orHigher(){
+            try {
+                Class.forName("java.util.Objects");
+                return true;
+            } catch (ClassNotFoundException ignore){
+                return false;
+            }
+        }
+
+        private static boolean isJava8orHigher(){
+            try {
+                Class.forName("java.util.Optional");
+                return true;
+            } catch (ClassNotFoundException ignore){
+                return false;
+            }
+        }
+
+        static class MethodHandleSupport {
+
+            static final Constructor<MethodHandles.Lookup> cachedLookupConstructor;
+
+            static {
+                if (JAVA_7_OR_HIGHER) {
+                    try {
+                        cachedLookupConstructor = MethodHandles.Lookup.class.getDeclaredConstructor(Class.class);
+
+                        if (!cachedLookupConstructor.isAccessible()) {
+                            cachedLookupConstructor.setAccessible(true);
+                        }
+                    } catch (Exception o_O) {
+                        throw new IllegalStateException(o_O);
+                    }
+                } else {
+                    cachedLookupConstructor = null;
+                }
+            }
+
+            static MethodHandles.Lookup lookupIn(Class<?> type) throws Throwable {
+                return (MethodHandles.Lookup) cachedLookupConstructor.newInstance(type);
+            }
+        }
+
+        static class DefaultMethodSupport {
+
+            static boolean isDefaultMethod(Method method){
+                //Java 8 guard to remain compatible with older Java Versions.
+                return JAVA_8_OR_HIGHER && method.isDefault();
+            }
+
+            static <P> Object invokeDefaultMethod(Object target, Class<P> type, Method method, Object... args) throws Throwable {
+                return MethodHandleSupport.lookupIn(type)
+                  .unreflectSpecial(method, type)
+                  .bindTo(target)
+                  .invokeWithArguments(args);
+            }
+        }
+    }
 }

--- a/jOOR/src/test/java/org/joor/test/InterfaceWithDefaultMethods.java
+++ b/jOOR/src/test/java/org/joor/test/InterfaceWithDefaultMethods.java
@@ -1,0 +1,15 @@
+package org.joor.test;
+
+/**
+ * @author Thomas Darimont
+ */
+public interface InterfaceWithDefaultMethods {
+
+  default int returnAnInt() {
+    return 42;
+  }
+
+  default int throwIllegalArgumentException(){
+    throw new IllegalArgumentException("oh oh");
+  }
+}

--- a/jOOR/src/test/java/org/joor/test/ReflectTest.java
+++ b/jOOR/src/test/java/org/joor/test/ReflectTest.java
@@ -43,10 +43,10 @@ public class ReflectTest {
     public void testOn() {
         assertEquals(on(Object.class), on("java.lang.Object", ClassLoader.getSystemClassLoader()));
         assertEquals(on(Object.class), on("java.lang.Object"));
-        assertEquals(on(Object.class).get(), on("java.lang.Object").get());
+        assertEquals((Object)on(Object.class).get(), on("java.lang.Object").get());
         assertEquals(Object.class, on(Object.class).get());
         assertEquals("abc", on((Object) "abc").get());
-        assertEquals(1, on(1).get());
+        assertEquals((Integer)1, on(1).get());
 
         try {
             on("asdf");
@@ -120,8 +120,8 @@ public class ReflectTest {
         assertEquals("12", on((Object) "1234").call("substring", 0, 2).get());
         assertEquals("1234", on((Object) "12").call("concat", "34").get());
         assertEquals("123456", on((Object) "12").call("concat", "34").call("concat", "56").get());
-        assertEquals(2, on((Object) "1234").call("indexOf", "3").get());
-        assertEquals(2.0f, on((Object) "1234").call("indexOf", "3").call("floatValue").get());
+        assertEquals((Integer)2, on((Object) "1234").call("indexOf", "3").get());
+        assertEquals((Float)2.0f, on((Object) "1234").call("indexOf", "3").call("floatValue").get());
         assertEquals("2", on((Object) "1234").call("indexOf", "3").call("toString").get());
 
         // Static methods
@@ -224,44 +224,44 @@ public class ReflectTest {
         // Instance methods
         // ----------------
         Test1 test1 = new Test1();
-        assertEquals(1, on(test1).set("I_INT1", 1).get("I_INT1"));
-        assertEquals(1, on(test1).field("I_INT1").get());
-        assertEquals(1, on(test1).set("I_INT2", 1).get("I_INT2"));
-        assertEquals(1, on(test1).field("I_INT2").get());
+        assertEquals((Integer)1, on(test1).set("I_INT1", 1).get("I_INT1"));
+        assertEquals((Integer)1, on(test1).field("I_INT1").get());
+        assertEquals((Integer)1, on(test1).set("I_INT2", 1).get("I_INT2"));
+        assertEquals((Integer)1, on(test1).field("I_INT2").get());
         assertNull(on(test1).set("I_INT2", null).get("I_INT2"));
         assertNull(on(test1).field("I_INT2").get());
 
         // Static methods
         // --------------
-        assertEquals(1, on(Test1.class).set("S_INT1", 1).get("S_INT1"));
-        assertEquals(1, on(Test1.class).field("S_INT1").get());
-        assertEquals(1, on(Test1.class).set("S_INT2", 1).get("S_INT2"));
-        assertEquals(1, on(Test1.class).field("S_INT2").get());
+        assertEquals((Integer)1, on(Test1.class).set("S_INT1", 1).get("S_INT1"));
+        assertEquals((Integer)1, on(Test1.class).field("S_INT1").get());
+        assertEquals((Integer)1, on(Test1.class).set("S_INT2", 1).get("S_INT2"));
+        assertEquals((Integer)1, on(Test1.class).field("S_INT2").get());
         assertNull(on(Test1.class).set("S_INT2", null).get("S_INT2"));
         assertNull(on(Test1.class).field("S_INT2").get());
 
         // Hierarchies
         // -----------
         TestHierarchicalMethodsSubclass test2 = new TestHierarchicalMethodsSubclass();
-        assertEquals(1, on(test2).set("invisibleField1", 1).get("invisibleField1"));
-        assertEquals(1, accessible(TestHierarchicalMethodsBase.class.getDeclaredField("invisibleField1")).get(test2));
+        assertEquals((Integer)1, on(test2).set("invisibleField1", 1).get("invisibleField1"));
+        assertEquals((Integer)1, accessible(TestHierarchicalMethodsBase.class.getDeclaredField("invisibleField1")).get(test2));
 
-        assertEquals(1, on(test2).set("invisibleField2", 1).get("invisibleField2"));
-        assertEquals(0, accessible(TestHierarchicalMethodsBase.class.getDeclaredField("invisibleField2")).get(test2));
-        assertEquals(1, accessible(TestHierarchicalMethodsSubclass.class.getDeclaredField("invisibleField2")).get(test2));
+        assertEquals((Integer)1, on(test2).set("invisibleField2", 1).get("invisibleField2"));
+        assertEquals((Integer)0, accessible(TestHierarchicalMethodsBase.class.getDeclaredField("invisibleField2")).get(test2));
+        assertEquals((Integer)1, accessible(TestHierarchicalMethodsSubclass.class.getDeclaredField("invisibleField2")).get(test2));
 
-        assertEquals(1, on(test2).set("invisibleField3", 1).get("invisibleField3"));
-        assertEquals(1, accessible(TestHierarchicalMethodsSubclass.class.getDeclaredField("invisibleField3")).get(test2));
+        assertEquals((Integer)1, on(test2).set("invisibleField3", 1).get("invisibleField3"));
+        assertEquals((Integer)1, accessible(TestHierarchicalMethodsSubclass.class.getDeclaredField("invisibleField3")).get(test2));
 
-        assertEquals(1, on(test2).set("visibleField1", 1).get("visibleField1"));
-        assertEquals(1, accessible(TestHierarchicalMethodsBase.class.getDeclaredField("visibleField1")).get(test2));
+        assertEquals((Integer)1, on(test2).set("visibleField1", 1).get("visibleField1"));
+        assertEquals((Integer)1, accessible(TestHierarchicalMethodsBase.class.getDeclaredField("visibleField1")).get(test2));
 
-        assertEquals(1, on(test2).set("visibleField2", 1).get("visibleField2"));
-        assertEquals(0, accessible(TestHierarchicalMethodsBase.class.getDeclaredField("visibleField2")).get(test2));
-        assertEquals(1, accessible(TestHierarchicalMethodsSubclass.class.getDeclaredField("visibleField2")).get(test2));
+        assertEquals((Integer)1, on(test2).set("visibleField2", 1).get("visibleField2"));
+        assertEquals((Integer)0, accessible(TestHierarchicalMethodsBase.class.getDeclaredField("visibleField2")).get(test2));
+        assertEquals((Integer)1, accessible(TestHierarchicalMethodsSubclass.class.getDeclaredField("visibleField2")).get(test2));
 
-        assertEquals(1, on(test2).set("visibleField3", 1).get("visibleField3"));
-        assertEquals(1, accessible(TestHierarchicalMethodsSubclass.class.getDeclaredField("visibleField3")).get(test2));
+        assertEquals((Integer)1, on(test2).set("visibleField3", 1).get("visibleField3"));
+        assertEquals((Integer)1, accessible(TestHierarchicalMethodsSubclass.class.getDeclaredField("visibleField3")).get(test2));
 
         assertNull(accessible(null));
     }
@@ -271,19 +271,19 @@ public class ReflectTest {
         // Instance methods
         // ----------------
         Test11 test11 = new Test11();
-        assertEquals(1, on(test11).set("F_INT1", 1).get("F_INT1"));
-        assertEquals(1, on(test11).field("F_INT1").get());
-        assertEquals(1, on(test11).set("F_INT2", 1).get("F_INT1"));
-        assertEquals(1, on(test11).field("F_INT2").get());
+        assertEquals((Integer)1, on(test11).set("F_INT1", 1).get("F_INT1"));
+        assertEquals((Integer)1, on(test11).field("F_INT1").get());
+        assertEquals((Integer)1, on(test11).set("F_INT2", 1).get("F_INT1"));
+        assertEquals((Integer)1, on(test11).field("F_INT2").get());
         assertNull(on(test11).set("F_INT2", null).get("F_INT2"));
         assertNull(on(test11).field("F_INT2").get());
 
         // Static methods
         // ----------------
-        assertEquals(1, on(Test11.class).set("SF_INT1", 1).get("SF_INT1"));
-        assertEquals(1, on(Test11.class).field("SF_INT1").get());
-        assertEquals(1, on(Test11.class).set("SF_INT2", 1).get("SF_INT2"));
-        assertEquals(1, on(Test11.class).field("SF_INT2").get());
+        assertEquals((Integer)1, on(Test11.class).set("SF_INT1", 1).get("SF_INT1"));
+        assertEquals((Integer)1, on(Test11.class).field("SF_INT1").get());
+        assertEquals((Integer)1, on(Test11.class).set("SF_INT2", 1).get("SF_INT2"));
+        assertEquals((Integer)1, on(Test11.class).field("SF_INT2").get());
         on(Test11.class).set("SF_INT2", 1).field("SF_INT2").get();;
         assertNull(on(Test11.class).set("SF_INT2", null).get("SF_INT2"));
         assertNull(on(Test11.class).field("SF_INT2").get());
@@ -317,10 +317,10 @@ public class ReflectTest {
         assertTrue(on(test1).fields().containsKey("I_INT2"));
         assertTrue(on(test1).fields().containsKey("I_DATA"));
 
-        assertEquals(1, on(test1).set("I_INT1", 1).fields().get("I_INT1").get());
-        assertEquals(1, on(test1).fields().get("I_INT1").get());
-        assertEquals(1, on(test1).set("I_INT2", 1).fields().get("I_INT2").get());
-        assertEquals(1, on(test1).fields().get("I_INT2").get());
+        assertEquals((Integer)1, on(test1).set("I_INT1", 1).fields().get("I_INT1").get());
+        assertEquals((Integer)1, on(test1).fields().get("I_INT1").get());
+        assertEquals((Integer)1, on(test1).set("I_INT2", 1).fields().get("I_INT2").get());
+        assertEquals((Integer)1, on(test1).fields().get("I_INT2").get());
         assertNull(on(test1).set("I_INT2", null).fields().get("I_INT2").get());
         assertNull(on(test1).fields().get("I_INT2").get());
 
@@ -331,10 +331,10 @@ public class ReflectTest {
         assertTrue(on(Test1.class).fields().containsKey("S_INT2"));
         assertTrue(on(Test1.class).fields().containsKey("S_DATA"));
 
-        assertEquals(1, on(Test1.class).set("S_INT1", 1).fields().get("S_INT1").get());
-        assertEquals(1, on(Test1.class).fields().get("S_INT1").get());
-        assertEquals(1, on(Test1.class).set("S_INT2", 1).fields().get("S_INT2").get());
-        assertEquals(1, on(Test1.class).fields().get("S_INT2").get());
+        assertEquals((Integer)1, on(Test1.class).set("S_INT1", 1).fields().get("S_INT1").get());
+        assertEquals((Integer)1, on(Test1.class).fields().get("S_INT1").get());
+        assertEquals((Integer)1, on(Test1.class).set("S_INT2", 1).fields().get("S_INT2").get());
+        assertEquals((Integer)1, on(Test1.class).fields().get("S_INT2").get());
         assertNull(on(Test1.class).set("S_INT2", null).fields().get("S_INT2").get());
         assertNull(on(Test1.class).fields().get("S_INT2").get());
 

--- a/jOOR/src/test/java/org/joor/test/ReflectTest.java
+++ b/jOOR/src/test/java/org/joor/test/ReflectTest.java
@@ -32,12 +32,18 @@ import org.joor.ReflectException;
 import org.joor.test.Test2.ConstructorType;
 import org.joor.test.Test3.MethodType;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  * @author Lukas Eder
+ * @author Thomas Darimont
  */
 public class ReflectTest {
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testOn() {
@@ -500,6 +506,20 @@ public class ReflectTest {
         assertTrue(a.equals(c));
         //noinspection ObjectEqualsNull
         assertFalse(a.equals(null));
+    }
+
+    @Test //See #31
+    public void shouldCallDefaultMethod(){
+
+        int answer = Reflect.on(new Object()).as(InterfaceWithDefaultMethods.class).returnAnInt();
+        assertEquals(42, answer);
+    }
+
+    @Test //See #31
+    public void shouldThrowExceptionThrownByDefaultMethod(){
+
+        expectedException.expect(IllegalArgumentException.class);
+        Reflect.on(new Object()).as(InterfaceWithDefaultMethods.class).throwIllegalArgumentException();
     }
 
     @Before


### PR DESCRIPTION
Using Java8 guard to remain compatible with older Java versions.
Revised maven compiler settings to build test sources with Java 8.

Verified the pre Java 8 compatibility with a Java 7 example project.

(Could be split up into separate PRs...)
Adjusted .gitignore to exclude project metadata
Fixed assertEquals checks that complain under Java 8.
