### PR TITLE
Removed MethodHandles import from Java-6.

### DIFF
--- a/jOOR-java-6/src/main/java/org/joor/Reflect.java
+++ b/jOOR-java-6/src/main/java/org/joor/Reflect.java
@@ -13,7 +13,6 @@
  */
 package org.joor;
 
-import java.lang.invoke.MethodHandles;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;


### PR DESCRIPTION
I removed an unused import from the Java-6 part of the repo. This makes it work on Android.

By the way, Android O will support [MethodHandles](https://developer.android.com/reference/java/lang/invoke/MethodHandles.html)