### PR TITLE
NPE in Reflect.toString() when wrapped object is null

### DIFF
--- a/jOOR-java-8/src/main/java/org/joor/Reflect.java
+++ b/jOOR-java-8/src/main/java/org/joor/Reflect.java
@@ -743,7 +743,7 @@ public class Reflect {
      */
     @Override
     public String toString() {
-        return object.toString();
+        return object == null ? null : object.toString();
     }
 
     // ---------------------------------------------------------------------


### PR DESCRIPTION
fix nep bug when call Reflect.fields method while object field value is null