### PR TITLE
Add CompileOptions.options to pass extra options to JavaCompiler

### DIFF
--- a/jOOR-java-8/src/main/java/org/joor/Compile.java
+++ b/jOOR-java-8/src/main/java/org/joor/Compile.java
@@ -86,6 +86,7 @@ class Compile {
                 }
 
                 options.addAll(Arrays.asList("-classpath", classpath.toString()));
+                options.addAll(compileOptions.extraOptions);
                 CompilationTask task = compiler.getTask(out, fileManager, null, options, null, files);
 
                 if (!compileOptions.processors.isEmpty())

--- a/jOOR-java-8/src/main/java/org/joor/CompileOptions.java
+++ b/jOOR-java-8/src/main/java/org/joor/CompileOptions.java
@@ -28,17 +28,21 @@ import javax.annotation.processing.Processor;
 public final class CompileOptions {
 
     final List<? extends Processor> processors;
+    final List<String> extraOptions;
 
     public CompileOptions() {
         this(
+            Collections.emptyList(),
             Collections.emptyList()
         );
     }
 
     private CompileOptions(
-        List<? extends Processor> processors
+        List<? extends Processor> processors,
+        List<String> extraOptions
     ) {
         this.processors = processors;
+        this.extraOptions = extraOptions;
     }
 
     public final CompileOptions processors(Processor... newProcessors) {
@@ -46,7 +50,19 @@ public final class CompileOptions {
     }
 
     public final CompileOptions processors(List<? extends Processor> newProcessors) {
-        return new CompileOptions(newProcessors);
+        return new CompileOptions(newProcessors, Collections.emptyList());
+    }
+
+    public final CompileOptions extraOptions(String... extraOptions) {
+        return extraOptions(Arrays.asList(extraOptions));
+    }
+
+    public final CompileOptions extraOptions(List<String> extraOptions) {
+        return new CompileOptions(Collections.emptyList(), extraOptions);
+    }
+
+    public final CompileOptions compileOptions(List<? extends Processor> newProcessors, List<String> extraOptions) {
+        return new CompileOptions(newProcessors, extraOptions);
     }
 }
 /* [/java-8] */

--- a/jOOR-java-8/src/test/java/org/joor/test/CompileOptionsTest.java
+++ b/jOOR-java-8/src/test/java/org/joor/test/CompileOptionsTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Lukas Eder
@@ -96,6 +97,18 @@ public class CompileOptionsTest {
             new CompileOptions().extraOptions("-source", "8")).create().get().getClass();
 
         // todo: check .class version, or create better test for extraOptions
+
+        try {
+            Reflect.compile(
+                "org.joor.test.Invalid",
+                "package org.joor.test; "
+                    + "public class Invalid {"
+                    + "}",
+                new CompileOptions().extraOptions("-invalidflag"));
+            fail("Expected ReflectException for -invalidflag");
+        } catch (ReflectException e) {
+            assertTrue(e.getCause() instanceof IllegalArgumentException);
+        }
     }
 
     static class AProcessor implements Processor {

--- a/jOOR-java-8/src/test/java/org/joor/test/CompileOptionsTest.java
+++ b/jOOR-java-8/src/test/java/org/joor/test/CompileOptionsTest.java
@@ -77,6 +77,27 @@ public class CompileOptionsTest {
         assertTrue(p.processed);
     }
 
+    @Test
+    public void testCompileWithExtraOptions() {
+        Class<?> source7Class = Reflect.compile(
+            "org.joor.test.Source7",
+            "package org.joor.test; "
+                + "public class Source7 {"
+                + "}",
+            new CompileOptions().extraOptions("-source", "7")).create().get().getClass();
+
+        // todo: check .class version, or create better test for extraOptions
+
+        Class<?> source8Class = Reflect.compile(
+            "org.joor.test.Source8",
+            "package org.joor.test; "
+                + "public class Source8 {"
+                + "}",
+            new CompileOptions().extraOptions("-source", "8")).create().get().getClass();
+
+        // todo: check .class version, or create better test for extraOptions
+    }
+
     static class AProcessor implements Processor {
         boolean processed;
 


### PR DESCRIPTION
I'd like to add the ability to add extra arguments to the compiler (only prototyped for Java 8 ATM). I'm not sure the easiest way to actually test the extra options in context of unit tests. Would a feature like this be welcome?