### PR TITLE
Overload unimplemented getCharContent method

### DIFF
--- a/jOOR-java-8/src/main/java/org/joor/Compile.java
+++ b/jOOR-java-8/src/main/java/org/joor/Compile.java
@@ -26,6 +26,7 @@ import java.lang.invoke.MethodHandles.Lookup;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.Charset;
 import java.util.*;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Map.Entry;
@@ -194,6 +195,11 @@ class Compile {
         @Override
         public OutputStream openOutputStream() {
             return os;
+        }
+
+        @Override
+        public CharSequence getCharContent(final boolean ignoreEncodingErrors) {
+            return new String(this.os.toByteArray(), Charset.forName("UTF-8"));
         }
     }
 


### PR DESCRIPTION
It seems that to be able to integrate with JavaPoet code generation tool this little tweak is needed.