### PR TITLE
[#5] Add MethodOverloadTests for each module

### DIFF
--- a/jOOR-java-6/src/test/java/org/joor/test/MethodOverloadTests.java
+++ b/jOOR-java-6/src/test/java/org/joor/test/MethodOverloadTests.java
@@ -1,0 +1,66 @@
+package org.joor.test;
+
+import org.joor.Reflect;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MethodOverloadTests {
+    // count each overload invocation
+    private static int sObject = 0;
+    private static int sNumber = 0;
+    private static int sInteger = 0;
+    private int mObject = 0;
+    private int mNumber = 0;
+    private int mInteger = 0;
+
+    private static void sOverload(Object o) {
+        MethodOverloadTests.sObject++;
+    }
+
+    private static void sOverload(Number number) {
+        MethodOverloadTests.sNumber++;
+    }
+
+    private static void sOverload(Integer integer) {
+        MethodOverloadTests.sInteger++;
+    }
+
+    private void mOverload(Object o) {
+        this.mObject++;
+    }
+
+    private void mOverload(Number number) {
+        this.mNumber++;
+    }
+
+    private void mOverload(Integer integer) {
+        this.mInteger++;
+    }
+
+    @Test
+    public void testStaticMethodsOverload() {
+        Reflect reflect = Reflect.onClass(MethodOverloadTests.class);
+        reflect.call("sOverload", Integer.parseInt("1"));
+        Assert.assertEquals(1, MethodOverloadTests.sInteger);
+
+        reflect.call("sOverload", Long.parseLong("1"));
+        Assert.assertEquals(1, MethodOverloadTests.sNumber);
+
+        reflect.call("sOverload", "Hello world!");
+        Assert.assertEquals(1, MethodOverloadTests.sObject);
+    }
+
+    @Test
+    public void testMemberMethodsOverload() {
+        MethodOverloadTests instance = new MethodOverloadTests();
+        Reflect reflect = Reflect.on(instance);
+        reflect.call("mOverload", Integer.parseInt("1"));
+        Assert.assertEquals(1, instance.mInteger);
+
+        reflect.call("mOverload", Long.parseLong("1"));
+        Assert.assertEquals(1, instance.mNumber);
+
+        reflect.call("mOverload", "Hello world!");
+        Assert.assertEquals(1, instance.mObject);
+    }
+}

--- a/jOOR-java-8/src/test/java/org/joor/test/MethodOverloadTests.java
+++ b/jOOR-java-8/src/test/java/org/joor/test/MethodOverloadTests.java
@@ -1,0 +1,66 @@
+package org.joor.test;
+
+import org.joor.Reflect;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MethodOverloadTests {
+    // count each overload invocation
+    private static int sObject = 0;
+    private static int sNumber = 0;
+    private static int sInteger = 0;
+    private int mObject = 0;
+    private int mNumber = 0;
+    private int mInteger = 0;
+
+    private static void sOverload(Object o) {
+        MethodOverloadTests.sObject++;
+    }
+
+    private static void sOverload(Number number) {
+        MethodOverloadTests.sNumber++;
+    }
+
+    private static void sOverload(Integer integer) {
+        MethodOverloadTests.sInteger++;
+    }
+
+    private void mOverload(Object o) {
+        this.mObject++;
+    }
+
+    private void mOverload(Number number) {
+        this.mNumber++;
+    }
+
+    private void mOverload(Integer integer) {
+        this.mInteger++;
+    }
+
+    @Test
+    public void testStaticMethodsOverload() {
+        Reflect reflect = Reflect.onClass(MethodOverloadTests.class);
+        reflect.call("sOverload", Integer.parseInt("1"));
+        Assert.assertEquals(1, MethodOverloadTests.sInteger);
+
+        reflect.call("sOverload", Long.parseLong("1"));
+        Assert.assertEquals(1, MethodOverloadTests.sNumber);
+
+        reflect.call("sOverload", "Hello world!");
+        Assert.assertEquals(1, MethodOverloadTests.sObject);
+    }
+
+    @Test
+    public void testMemberMethodsOverload() {
+        MethodOverloadTests instance = new MethodOverloadTests();
+        Reflect reflect = Reflect.on(instance);
+        reflect.call("mOverload", Integer.parseInt("1"));
+        Assert.assertEquals(1, instance.mInteger);
+
+        reflect.call("mOverload", Long.parseLong("1"));
+        Assert.assertEquals(1, instance.mNumber);
+
+        reflect.call("mOverload", "Hello world!");
+        Assert.assertEquals(1, instance.mObject);
+    }
+}

--- a/jOOR/src/test/java/org/joor/test/MethodOverloadTests.java
+++ b/jOOR/src/test/java/org/joor/test/MethodOverloadTests.java
@@ -1,0 +1,66 @@
+package org.joor.test;
+
+import org.joor.Reflect;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MethodOverloadTests {
+    // count each overload invocation
+    private static int sObject = 0;
+    private static int sNumber = 0;
+    private static int sInteger = 0;
+    private int mObject = 0;
+    private int mNumber = 0;
+    private int mInteger = 0;
+
+    private static void sOverload(Object o) {
+        MethodOverloadTests.sObject++;
+    }
+
+    private static void sOverload(Number number) {
+        MethodOverloadTests.sNumber++;
+    }
+
+    private static void sOverload(Integer integer) {
+        MethodOverloadTests.sInteger++;
+    }
+
+    private void mOverload(Object o) {
+        this.mObject++;
+    }
+
+    private void mOverload(Number number) {
+        this.mNumber++;
+    }
+
+    private void mOverload(Integer integer) {
+        this.mInteger++;
+    }
+
+    @Test
+    public void testStaticMethodsOverload() {
+        Reflect reflect = Reflect.onClass(MethodOverloadTests.class);
+        reflect.call("sOverload", Integer.parseInt("1"));
+        Assert.assertEquals(1, MethodOverloadTests.sInteger);
+
+        reflect.call("sOverload", Long.parseLong("1"));
+        Assert.assertEquals(1, MethodOverloadTests.sNumber);
+
+        reflect.call("sOverload", "Hello world!");
+        Assert.assertEquals(1, MethodOverloadTests.sObject);
+    }
+
+    @Test
+    public void testMemberMethodsOverload() {
+        MethodOverloadTests instance = new MethodOverloadTests();
+        Reflect reflect = Reflect.on(instance);
+        reflect.call("mOverload", Integer.parseInt("1"));
+        Assert.assertEquals(1, instance.mInteger);
+
+        reflect.call("mOverload", Long.parseLong("1"));
+        Assert.assertEquals(1, instance.mNumber);
+
+        reflect.call("mOverload", "Hello world!");
+        Assert.assertEquals(1, instance.mObject);
+    }
+}


### PR DESCRIPTION
I tested these three test cases. They works fine, but if any fails, try clean and run again.
(Maybe we should migrate to JUnit5 and annount with `@RepeatTest`)

My environment:
```
IntelliJ IDEA 2020.3.1
Build #IU-203.6682.168, built on December 29, 2020
Runtime version: 11.0.9.1+11-b1145.63 amd64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
Windows 10 10.0
```

ref:
#5 

ps:
There is something wrong with jOOR-java-6 and jOOR-java-8's existing test cases.
