### PR TITLE
support for -proc:only compiler option

### DIFF
--- a/jOOR-java-8/pom.xml
+++ b/jOOR-java-8/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.jooq</groupId>
     <artifactId>joor-java-8</artifactId>
-    <version>0.9.14</version>
+    <version>0.9.14.2</version>
     <packaging>bundle</packaging>
 
     <name>jOOR</name>

--- a/jOOR-java-8/src/main/java/org/joor/Compile.java
+++ b/jOOR-java-8/src/main/java/org/joor/Compile.java
@@ -95,7 +95,7 @@ class Compile {
                     options.addAll(Arrays.asList("-classpath", classpath.toString()));
                 }
 
-                CompilationTask task = compiler.getTask(out, fileManager, null, options, null, files);
+                CompilationTask task = compiler.getTask(out, fileManager, compileOptions.diagnosticListener, options, null, files);
 
                 if (!compileOptions.processors.isEmpty())
                     task.setProcessors(compileOptions.processors);
@@ -103,7 +103,7 @@ class Compile {
                 task.call();
 
                 if (fileManager.isEmpty()) {
-                    if (compileOptions.hashOption("-proc:only")) {
+                    if (compileOptions.hasOption("-proc:only")) {
                         return null;
                     }
                     throw new ReflectException("Compilation error: " + out);

--- a/jOOR-java-8/src/main/java/org/joor/Compile.java
+++ b/jOOR-java-8/src/main/java/org/joor/Compile.java
@@ -102,8 +102,12 @@ class Compile {
 
                 task.call();
 
-                if (fileManager.isEmpty())
+                if (fileManager.isEmpty()) {
+                    if (compileOptions.hashOption("-proc:only")) {
+                        return null;
+                    }
                     throw new ReflectException("Compilation error: " + out);
+                }
 
                 Class<?> result = null;
 

--- a/jOOR-java-8/src/main/java/org/joor/CompileOptions.java
+++ b/jOOR-java-8/src/main/java/org/joor/CompileOptions.java
@@ -21,6 +21,8 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.processing.Processor;
+import javax.tools.DiagnosticListener;
+import javax.tools.JavaFileObject;
 
 /**
  * @author Lukas Eder
@@ -29,6 +31,7 @@ public final class CompileOptions {
 
     final List<? extends Processor> processors;
     final List<String> options;
+    DiagnosticListener<JavaFileObject> diagnosticListener;
 
     public CompileOptions() {
         this(
@@ -61,7 +64,7 @@ public final class CompileOptions {
         return new CompileOptions(processors, newOptions);
     }
 
-    public boolean hashOption(String opt) {
+    public boolean hasOption(String opt) {
         for (String option : options) {
             if (option.equalsIgnoreCase(opt)) {
                 return true;
@@ -69,5 +72,11 @@ public final class CompileOptions {
         }
         return false;
     }
+
+    public CompileOptions withDiagnosticListener(DiagnosticListener<JavaFileObject> listener) {
+        this.diagnosticListener = listener;
+        return this;
+    }
+
 }
 

--- a/jOOR-java-8/src/main/java/org/joor/CompileOptions.java
+++ b/jOOR-java-8/src/main/java/org/joor/CompileOptions.java
@@ -60,5 +60,14 @@ public final class CompileOptions {
     public final CompileOptions options(List<String> newOptions) {
         return new CompileOptions(processors, newOptions);
     }
+
+    public boolean hashOption(String opt) {
+        for (String option : options) {
+            if (option.equalsIgnoreCase(opt)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }
 

--- a/jOOR-java-8/src/main/java/org/joor/Reflect.java
+++ b/jOOR-java-8/src/main/java/org/joor/Reflect.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Proxy;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -198,7 +199,7 @@ public class Reflect {
      * @return A wrapped class object, to be used for further reflection.
      */
     public static Reflect onClass(Class<?> clazz) {
-        return new Reflect(clazz);
+        return Objects.isNull(clazz) ? null : new Reflect(clazz);
     }
 
     /**

--- a/jOOR-java-8/src/test/java/org/joor/test/CompileOptionsTest.java
+++ b/jOOR-java-8/src/test/java/org/joor/test/CompileOptionsTest.java
@@ -13,14 +13,10 @@
  */
 package org.joor.test;
 
-import java.io.Serializable;
 import java.util.Collections;
 
 
-
-import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Supplier;
 
 import javax.annotation.processing.Completion;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -35,7 +31,6 @@ import javax.lang.model.element.TypeElement;
 import org.joor.CompileOptions;
 import org.joor.Reflect;
 import org.joor.ReflectException;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -178,6 +173,18 @@ public class CompileOptionsTest {
             return Collections.emptyList();
         }
     }
+
+    /**
+     * -proc:only is a standard option and should be supported.
+     * see https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javac.html
+     */
+    @Test
+    public void testProcOnly() {
+        Object result = Reflect.compile("p.D", "package p; public class D extends B {} class B {}",
+                                        new CompileOptions().options("-proc:only").processors(new AProcessor()));
+        assertNull(result);
+    }
+
 }
 
 @interface A {}

--- a/jOOR-java-8/src/test/java/org/joor/test/CompileOptionsTest.java
+++ b/jOOR-java-8/src/test/java/org/joor/test/CompileOptionsTest.java
@@ -15,8 +15,9 @@ package org.joor.test;
 
 import java.util.Collections;
 
-
+import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.processing.Completion;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -27,6 +28,7 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
 
 import org.joor.CompileOptions;
 import org.joor.Reflect;
@@ -154,6 +156,7 @@ public class CompileOptionsTest {
 
         @Override
         public void init(ProcessingEnvironment processingEnv) {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.NOTE, "running " + getClass().getName());
         }
 
         @Override
@@ -179,10 +182,16 @@ public class CompileOptionsTest {
      * see https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javac.html
      */
     @Test
-    public void testProcOnly() {
+    public void testProcOnlyWithDiagnostics() {
+        AtomicReference<String> diagMessage = new AtomicReference<>();
         Object result = Reflect.compile("p.D", "package p; public class D extends B {} class B {}",
-                                        new CompileOptions().options("-proc:only").processors(new AProcessor()));
+                                        new CompileOptions().options("-proc:only")
+                                                .processors(new AProcessor())
+                                                .withDiagnosticListener(diagnostic -> {
+                                                    diagMessage.set(diagnostic.getMessage(Locale.ENGLISH));
+                                                }));
         assertNull(result);
+        assertNotNull(diagMessage.get());
     }
 
 }


### PR DESCRIPTION
Writing tests that only exercises annotation processing w/o needing to compile since it has better performance; this option is now supported with this change.